### PR TITLE
Speedup ci cache mingw

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -97,6 +97,10 @@ jobs:
         build_type: [ Debug, Release ]
     steps:
       - uses: actions/checkout@v2
+      - uses: actions/cache@v2
+        with:
+          path: C:\ProgramData\chocolatey\lib\mingw
+          key: ${{runner.os}}-chocolatey-mingw-${{matrix.mingw}}
 
       - name: Install Dependencies
         run: choco upgrade mingw -y --version=${{matrix.mingw}} --no-progress --allow-downgrade


### PR DESCRIPTION
Windows builds in particular are too slow. So cache the mingw installed by choco, can speed build up by about 2 minutes when cache hits.