### PR TITLE
Fix project language statistics

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,4 +1,5 @@
 deps/quickjs/tests/* linguist-vendored
 deps/quickjs/examples/* linguist-vendored
 deps/quickjs/doc/* linguist-vendored
+deps/quickjs/*.js linguist-vendored
 test/resources/* linguist-vendored

--- a/.gitattributes
+++ b/.gitattributes
@@ -1,3 +1,4 @@
 deps/quickjs/tests/* linguist-vendored
 deps/quickjs/examples/* linguist-vendored
 deps/quickjs/doc/* linguist-vendored
+test/resources/* linguist-vendored

--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,3 @@
+deps/quickjs/tests/* linguist-vendored
+deps/quickjs/examples/* linguist-vendored
+deps/quickjs/doc/* linguist-vendored

--- a/test/lib/core/nooprenderer.h
+++ b/test/lib/core/nooprenderer.h
@@ -21,6 +21,8 @@ namespace complate {
 
 class NoopRenderer : public Renderer {
 public:
+  ~NoopRenderer() override = default;
+
   void render(const std::string &, const Object &, Stream &) override{};
   void render(const std::string &, const std::string &, Stream &) override{};
 };


### PR DESCRIPTION
Many files in project tracked by linguist should not counting for linguist because they are generated or just tests from thrid party code. So i exclude them from the project statistics.